### PR TITLE
feat(docs): Add sidebar navigation to user manual

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -1,0 +1,16 @@
+<nav>
+  <h3><a href="{{ '/' | relative_url }}">Home</a></h3>
+  <ul>
+    <li><strong><a href="{{ '/#installation' | relative_url }}">Installation</a></strong></li>
+    <li><strong><a href="{{ '/#global-options' | relative_url }}">Global Options</a></strong></li>
+    <li><strong>Tutorials</strong>
+      <ul>
+        <li><a href="{{ '/tutorials/count_tutorial.html' | relative_url }}">Counting K-mers (`count`)</a></li>
+        <li><a href="{{ '/tutorials/build_tutorial.html' | relative_url }}">Building Databases (`build`)</a></li>
+        <li><a href="{{ '/tutorials/compare_tutorial.html' | relative_url }}">Comparing Databases (`compare`)</a></li>
+        <li><a href="{{ '/tutorials/query_tutorial.html' | relative_url }}">Querying Reads (`query`)</a></li>
+      </ul>
+    </li>
+    <li><strong><a href="{{ '/#example-workflow' | relative_url }}">Example Workflow</a></strong></li>
+  </ul>
+</nav>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="UTF-F-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+{% seo %}
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <!--[if lt IE 9]>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+    <![endif]-->
+    {% include head-custom.html %}
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="sidebar">
+        {% include sidebar.html %}
+      </div>
+      <div class="main-content-wrapper">
+        <header>
+          <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
+
+          {% if site.logo %}
+            <img src="{{site.logo | relative_url}}" alt="Logo" />
+          {% endif %}
+
+          <p>{{ site.description | default: site.github.project_tagline }}</p>
+
+          {% if site.github.is_project_page %}
+          <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>
+          {% endif %}
+
+          {% if site.github.is_user_page %}
+          <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
+          {% endif %}
+
+          {% if site.show_downloads %}
+          <ul class="downloads">
+            <li><a href="{{ site.github.zip_url }}">Download <strong>ZIP File</strong></a></li>
+            <li><a href="{{ site.github.tar_url }}">Download <strong>TAR Ball</strong></a></li>
+            <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
+          </ul>
+          {% endif %}
+        </header>
+        <section>
+
+        {{ content }}
+
+        </section>
+        <footer>
+          {% if site.github.is_project_page %}
+          <p>This project is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+          {% endif %}
+          <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
+        </footer>
+      </div> <!-- .main-content-wrapper -->
+    </div> <!-- .wrapper -->
+    <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
+  </body>
+</html>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,70 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+/* Custom styles for sidebar layout */
+.wrapper {
+  display: flex;
+  align-items: flex-start; /* Align items to the top */
+}
+
+.sidebar {
+  width: 250px; /* Fixed width for the sidebar */
+  padding: 20px;
+  border-right: 1px solid #eee;
+  height: 100vh; /* Full height */
+  overflow-y: auto; /* Scrollable if content overflows */
+  position: sticky; /* Sticky sidebar */
+  top: 0;
+}
+
+.sidebar nav ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+.sidebar nav ul ul {
+  padding-left: 20px; /* Indent sub-items */
+}
+
+.sidebar nav a {
+  text-decoration: none;
+  color: #333; /* Adjust color as needed */
+}
+
+.sidebar nav a:hover {
+  text-decoration: underline;
+}
+
+
+.main-content-wrapper {
+  flex-grow: 1; /* Allows the main content to take up remaining space */
+  padding: 20px;
+  max-width: calc(100% - 290px); /* Adjust based on sidebar width + padding + border */
+}
+
+/* Ensure header and footer within main-content-wrapper behave as expected */
+.main-content-wrapper header,
+.main-content-wrapper section,
+.main-content-wrapper footer {
+  max-width: 100%; /* Override default max-width from theme if needed */
+  float: none; /* Ensure no float issues from original theme */
+}
+
+/* Responsive adjustments (optional basic example) */
+@media screen and (max-width: 768px) {
+  .wrapper {
+    flex-direction: column;
+  }
+  .sidebar {
+    width: 100%;
+    height: auto;
+    position: static;
+    border-right: none;
+    border-bottom: 1px solid #eee;
+  }
+  .main-content-wrapper {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
This commit implements a sidebar navigation for the Orion-Kmer user manual to enhance usability.

Changes include:
- Modified `docs/_layouts/default.html` to introduce a two-column layout (sidebar and main content).
- Created `docs/_includes/sidebar.html` containing the navigation links, derived from the main page's table of contents.
- Added custom CSS to `docs/assets/css/style.scss` for:
  - Styling the sidebar (width, position, scrolling).
  - Styling the main content area to coexist with the sidebar.
  - Basic responsive behavior, stacking the sidebar above content on smaller screens.

The sidebar provides quick access to all major sections and tutorial pages of the manual.