### PR TITLE
Style: Reduce header prominence on sub-pages

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,7 +12,7 @@
     <![endif]-->
     {% include head-custom.html %}
   </head>
-  <body>
+  <body {% if page.url == "/" or page.name == "index.md" %}class="homepage"{% endif %}>
     <div class="wrapper">
       <div class="sidebar">
         {% include sidebar.html %}

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -68,3 +68,33 @@
     max-width: 100%;
   }
 }
+
+// Customizations for non-home pages
+body:not(.homepage) .main-content-wrapper header {
+  padding-top: 1rem;    // Reduce top padding of the header area
+  padding-bottom: 1rem; // Reduce bottom padding of the header area
+  margin-bottom: 1rem; // Default might be more, this tightens space to section
+}
+
+body:not(.homepage) .main-content-wrapper header h1 {
+  font-size: 1.8em; // Reduce project name font size (adjust as needed)
+}
+
+body:not(.homepage) .main-content-wrapper header p {
+  font-size: 0.9em; // Reduce tagline font size
+  margin-bottom: 0.5rem; // Reduce space below tagline
+}
+
+// Hide the .view class (View on GitHub links) in header on non-home pages to save space
+body:not(.homepage) .main-content-wrapper header p.view {
+  display: none;
+}
+
+// Example: If we wanted to make the sidebar slightly narrower on non-home pages
+// body:not(.homepage) .sidebar {
+//   width: 220px; // Slightly narrower sidebar
+// }
+
+// body:not(.homepage) .main-content-wrapper {
+//   max-width: calc(100% - 260px); // Adjust if sidebar width changes
+// }


### PR DESCRIPTION
Modified the Jekyll layout and CSS to make the site header (title, tagline) less intrusive on sub-pages compared to the home page.

- Added a 'homepage' class to the body of index.md.
- Applied custom CSS to target header elements on pages without the 'homepage' class, reducing font sizes and spacing.