### PR TITLE
Add min_coverage and output_tsv options to classify

### DIFF
--- a/orion-kmer/Cargo.toml
+++ b/orion-kmer/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "1.0"
 anyhow = "1.0"
 indicatif = "0.17" # For progress bars
 psutil = "3.2"     # For system utilities like RAM usage
+csv = "1.3"        # For TSV output
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/orion-kmer/README.md
+++ b/orion-kmer/README.md
@@ -180,11 +180,13 @@ orion-kmer classify -i <INPUT_FASTA_OR_FASTQ> -d <DB1.db> [DB2.db ...] -o <OUTPU
 *   `-o, --output <FILE>`: Output file for classification results (JSON format) \[required].
 *   `--kmer-size <INT>`: Optional. If provided, this k-mer size is validated against the k-mer size stored in the databases. The command will fail if they don't match. If not provided, the k-mer size from the first database is used, and subsequent databases are validated against it.
 *   `--min-kmer-frequency <INT>`: Minimum frequency for a k-mer in the input file to be considered for matching and depth calculations \[default: 1].
+    *   `--min-coverage <FLOAT>`: Minimum reference breadth of coverage (proportion of reference k-mers found in input) to include a reference in the output JSON and TSV reports \[default: 0.0].
+    *   `--output-tsv <FILE>`: Optional. Output file path for a TSV summary of the classification results. This summary includes one row per reference that meets the `--min-coverage` threshold.
 
 **Example:**
 
 ```bash
-orion-kmer classify -i my_reads.fastq -d ref_genome1.db pathogen_panel.db -o classification_report.json
+orion-kmer classify -i my_reads.fastq -d ref_genome1.db pathogen_panel.db -o classification_report.json --min-coverage 0.05 --output-tsv classification_summary.tsv
 ```
 
 **Output JSON Structure Example:**

--- a/orion-kmer/src/cli.rs
+++ b/orion-kmer/src/cli.rs
@@ -169,8 +169,20 @@ pub struct ClassifyArgs {
         help = "Minimum frequency for a k-mer in the input to be considered for depth calculation"
     )]
     pub min_kmer_frequency: usize,
-}
 
+    #[clap(
+        long,
+        default_value_t = 0.0,
+        help = "Minimum reference breadth of coverage to include a reference in the output"
+    )]
+    pub min_coverage: f64,
+
+    #[clap(
+        long,
+        help = "Optional: Output file path for a TSV summary of the classification results"
+    )]
+    pub output_tsv: Option<PathBuf>,
+}
 
 pub fn parse_cli() -> Cli {
     Cli::parse()

--- a/orion-kmer/src/commands/build.rs
+++ b/orion-kmer/src/commands/build.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use dashmap::DashSet; // Using DashSet for concurrent k-mer collection per file
 use log::{debug, info};
-use needletail::{parse_fastx_file, Sequence}; // Corrected import order
+use needletail::{Sequence, parse_fastx_file}; // Corrected import order
 use std::{
     collections::HashSet, // Keep HashSet for final storage in KmerDbV2
     fs::File,
@@ -52,7 +52,8 @@ fn process_sequences_for_file(
             }
         }
         record_count += 1;
-        if record_count % 100_000 == 0 { // Keep debug logging for detailed progress
+        if record_count % 100_000 == 0 {
+            // Keep debug logging for detailed progress
             debug!(
                 "Processed {} records from {}. Current unique k-mers for this file: {}",
                 record_count,
@@ -97,12 +98,10 @@ pub fn run_build(args: BuildArgs) -> Result<()> {
 
             let final_file_kmers: HashSet<u64> = file_kmer_set.into_iter().collect();
 
-            let reference_name = input_path
-                .file_name()
-                .map_or_else(
-                    || input_path.to_string_lossy().into_owned(),
-                    |os_str| os_str.to_string_lossy().into_owned(),
-                );
+            let reference_name = input_path.file_name().map_or_else(
+                || input_path.to_string_lossy().into_owned(),
+                |os_str| os_str.to_string_lossy().into_owned(),
+            );
 
             info!(
                 "Adding {} unique k-mers from reference '{}' to the database.",

--- a/orion-kmer/src/commands/classify.rs
+++ b/orion-kmer/src/commands/classify.rs
@@ -15,7 +15,8 @@ use crate::{
     kmer::{canonical_u64, seq_to_u64},
     utils::{load_kmer_db_v2, track_progress_and_resources}, // Import the wrapper
 };
-use needletail::{parse_fastx_file, Sequence};
+use csv;
+use needletail::{Sequence, parse_fastx_file};
 // use indicatif::ProgressBar; // Not strictly needed for the closure signature if pb is not used inside
 
 // --- Output Structures ---
@@ -28,7 +29,7 @@ struct ReferenceClassificationResult {
     sum_depth_of_matched_kmers_in_input: usize,
     avg_depth_of_matched_kmers_in_input: f64, // (sum_depth / input_kmers_hitting_reference)
     proportion_input_kmers_hitting_reference: f64, // (input_kmers_hitting_reference / total_unique_input_kmers)
-    reference_breadth_of_coverage: f64,       // (input_kmers_hitting_reference / total_kmers_in_reference)
+    reference_breadth_of_coverage: f64, // (input_kmers_hitting_reference / total_kmers_in_reference)
 }
 
 #[derive(Serialize, Debug)]
@@ -55,8 +56,12 @@ struct ClassificationOutput {
 // --- Main Logic ---
 
 pub fn run_classify(args: ClassifyArgs) -> Result<()> {
-    eprintln!("DEBUG: Entered run_classify. Input file: {:?}, Num DBs: {}, Output: {:?}",
-        args.input_file, args.database_files.len(), args.output_file); // Basic entry print
+    eprintln!(
+        "DEBUG: Entered run_classify. Input file: {:?}, Num DBs: {}, Output: {:?}",
+        args.input_file,
+        args.database_files.len(),
+        args.output_file
+    ); // Basic entry print
     info!("Starting classify command with args: {:?}", args);
 
     // --- 1. Load databases and determine/validate k ---
@@ -71,28 +76,42 @@ pub fn run_classify(args: ClassifyArgs) -> Result<()> {
         info!("User specified k-mer size for validation: {}", user_k);
     }
 
-    for (_i, db_path) in args.database_files.iter().enumerate() { // Changed i to _i
+    for (_i, db_path) in args.database_files.iter().enumerate() {
+        // Changed i to _i
         let kmer_db = load_kmer_db_v2(db_path)
             .with_context(|| format!("Failed to load database: {:?}", db_path))?;
 
         if let Some(current_k) = final_k {
             if kmer_db.k != current_k {
-                if args.kmer_size.is_some() { // Mismatch against user-provided k
+                if args.kmer_size.is_some() {
+                    // Mismatch against user-provided k
                     return Err(OrionKmerError::KmerSizeMismatchValidation(
-                        current_k, kmer_db.k, db_path.clone(),
-                    ).into());
-                } else { // Mismatch against k from the first database
+                        current_k,
+                        kmer_db.k,
+                        db_path.clone(),
+                    )
+                    .into());
+                } else {
+                    // Mismatch against k from the first database
                     return Err(OrionKmerError::KmerSizeMismatchBetweenDatabases(
-                        current_k, kmer_db.k, db_path.clone(),
-                    ).into());
+                        current_k,
+                        kmer_db.k,
+                        db_path.clone(),
+                    )
+                    .into());
                 }
             }
-        } else { // This is the first database and user did not provide k
-            if kmer_db.k == 0 || kmer_db.k > 32 { // Validate k from first DB
+        } else {
+            // This is the first database and user did not provide k
+            if kmer_db.k == 0 || kmer_db.k > 32 {
+                // Validate k from first DB
                 return Err(OrionKmerError::InvalidKmerSize(kmer_db.k).into());
             }
             final_k = Some(kmer_db.k);
-            info!("Effective k-mer size set to {} from first database {:?}", kmer_db.k, db_path);
+            info!(
+                "Effective k-mer size set to {} from first database {:?}",
+                kmer_db.k, db_path
+            );
         }
         loaded_databases.push(kmer_db);
     }
@@ -106,11 +125,13 @@ pub fn run_classify(args: ClassifyArgs) -> Result<()> {
         }
         None => {
             // Should not happen if args.database_files is required and not empty by clap
-            return Err(OrionKmerError::Generic("No databases provided to determine k-mer size.".to_string()).into());
+            return Err(OrionKmerError::Generic(
+                "No databases provided to determine k-mer size.".to_string(),
+            )
+            .into());
         }
     };
     info!("Processing with effective k-mer size: {}", k);
-
 
     // --- 2. Process input file: count k-mers ---
     let mut input_kmer_counts: HashMap<u64, usize> = HashMap::new();
@@ -121,16 +142,16 @@ pub fn run_classify(args: ClassifyArgs) -> Result<()> {
         0, // 0 for indeterminate progress bar (spinner style) as we don't know total records easily
         |pb_input| {
             let mut reader = parse_fastx_file(&args.input_file).with_context(|| {
-                format!(
-                    "Failed to open or parse input file: {:?}",
-                    args.input_file
-                )
+                format!("Failed to open or parse input file: {:?}", args.input_file)
             })?;
 
             let mut processed_records = 0;
             while let Some(record) = reader.next() {
                 let record = record.with_context(|| {
-                    format!("Error reading record from input file: {:?}", args.input_file)
+                    format!(
+                        "Error reading record from input file: {:?}",
+                        args.input_file
+                    )
                 })?;
                 let norm_seq = record.normalize(false);
 
@@ -143,12 +164,16 @@ pub fn run_classify(args: ClassifyArgs) -> Result<()> {
                     }
                 }
                 processed_records += 1;
-                if processed_records % 100_000 == 0 { // Update progress bar message periodically
+                if processed_records % 100_000 == 0 {
+                    // Update progress bar message periodically
                     pb_input.set_message(format!("Processed {} records...", processed_records));
                 }
                 // We don't call pb_input.inc() here as length is 0 (spinner)
             }
-            pb_input.set_message(format!("Processed {} total records from input file.", processed_records));
+            pb_input.set_message(format!(
+                "Processed {} total records from input file.",
+                processed_records
+            ));
             Ok(())
         },
     )?;
@@ -167,89 +192,114 @@ pub fn run_classify(args: ClassifyArgs) -> Result<()> {
     let total_unique_input_kmers_after_filter = filtered_input_kmer_counts.len();
     info!(
         "After applying min_kmer_frequency filter (>= {}), {} unique k-mers remain in input.",
-        args.min_kmer_frequency,
-        total_unique_input_kmers_after_filter
+        args.min_kmer_frequency, total_unique_input_kmers_after_filter
     );
 
     // --- 3. Perform classification ---
     let mut db_results: Vec<DatabaseClassificationResult> = Vec::new();
     let num_databases = loaded_databases.len() as u64;
 
-    track_progress_and_resources("Classifying against databases", num_databases, |pb_classify| {
-        for (idx, kmer_db_v2) in loaded_databases.iter().enumerate() {
-            let db_path_str = args.database_files[idx].to_string_lossy().into_owned();
-            info!("Classifying against database: {}", db_path_str);
-            pb_classify.set_message(format!("Classifying against: {}", db_path_str));
+    track_progress_and_resources(
+        "Classifying against databases",
+        num_databases,
+        |pb_classify| {
+            for (idx, kmer_db_v2) in loaded_databases.iter().enumerate() {
+                let db_path_str = args.database_files[idx].to_string_lossy().into_owned();
+                info!("Classifying against database: {}", db_path_str);
+                pb_classify.set_message(format!("Classifying against: {}", db_path_str));
 
-            let mut overall_matched_kmers_in_db_set: HashSet<u64> = HashSet::new();
-            let overall_sum_depth_for_db: usize;
-        let mut per_reference_results: Vec<ReferenceClassificationResult> = Vec::new();
+                let mut overall_matched_kmers_in_db_set: HashSet<u64> = HashSet::new();
+                let overall_sum_depth_for_db: usize;
+                let mut per_reference_results: Vec<ReferenceClassificationResult> = Vec::new();
 
-        for (ref_name, ref_kmers_set) in &kmer_db_v2.references {
-            debug!("Processing reference: {} from {}", ref_name, db_path_str);
-            // ---- END DEBUG PRINT ----
-            let mut matched_kmers_for_ref_set: HashSet<u64> = HashSet::new();
-            let mut sum_depth_for_ref: usize = 0;
+                for (ref_name, ref_kmers_set) in &kmer_db_v2.references {
+                    debug!("Processing reference: {} from {}", ref_name, db_path_str);
+                    // ---- END DEBUG PRINT ----
+                    let mut matched_kmers_for_ref_set: HashSet<u64> = HashSet::new();
+                    let mut sum_depth_for_ref: usize = 0;
 
-            for (input_kmer, input_count) in &filtered_input_kmer_counts {
-                if ref_kmers_set.contains(input_kmer) {
-                    matched_kmers_for_ref_set.insert(*input_kmer);
-                    sum_depth_for_ref += input_count;
-                    overall_matched_kmers_in_db_set.insert(*input_kmer); // Add to overall set for the DB
+                    for (input_kmer, input_count) in &filtered_input_kmer_counts {
+                        if ref_kmers_set.contains(input_kmer) {
+                            matched_kmers_for_ref_set.insert(*input_kmer);
+                            sum_depth_for_ref += input_count;
+                            overall_matched_kmers_in_db_set.insert(*input_kmer); // Add to overall set for the DB
+                        }
+                    }
+
+                    let num_matched_for_ref = matched_kmers_for_ref_set.len();
+                    let total_kmers_in_ref = ref_kmers_set.len();
+
+                    let reference_breadth_of_coverage = if total_kmers_in_ref > 0 {
+                        num_matched_for_ref as f64 / total_kmers_in_ref as f64
+                    } else {
+                        0.0
+                    };
+
+                    if reference_breadth_of_coverage >= args.min_coverage {
+                        per_reference_results.push(ReferenceClassificationResult {
+                            reference_name: ref_name.clone(),
+                            total_kmers_in_reference: total_kmers_in_ref,
+                            input_kmers_hitting_reference: num_matched_for_ref,
+                            sum_depth_of_matched_kmers_in_input: sum_depth_for_ref,
+                            avg_depth_of_matched_kmers_in_input: if num_matched_for_ref > 0 {
+                                sum_depth_for_ref as f64 / num_matched_for_ref as f64
+                            } else {
+                                0.0
+                            },
+                            proportion_input_kmers_hitting_reference:
+                                if total_unique_input_kmers_after_filter > 0 {
+                                    num_matched_for_ref as f64
+                                        / total_unique_input_kmers_after_filter as f64
+                                } else {
+                                    0.0
+                                },
+                            reference_breadth_of_coverage,
+                        });
+                    }
                 }
+
+                // Calculate sum of depths for overall_matched_kmers_in_db_set
+                // This needs to iterate input_kmer_counts again, specifically for k-mers in overall_matched_kmers_in_db_set
+                overall_sum_depth_for_db = overall_matched_kmers_in_db_set
+                    .iter()
+                    .map(|kmer| filtered_input_kmer_counts.get(kmer).copied().unwrap_or(0))
+                    .sum();
+
+                let num_overall_matched_kmers = overall_matched_kmers_in_db_set.len();
+                // ---- END DEBUG PRINT ----
+                let total_kmers_in_db_union = kmer_db_v2.total_unique_kmers();
+
+                db_results.push(DatabaseClassificationResult {
+                    database_path: db_path_str,
+                    database_kmer_size: kmer_db_v2.k,
+                    total_unique_kmers_in_db_across_references: total_kmers_in_db_union,
+                    overall_input_kmers_matched_in_db: num_overall_matched_kmers,
+                    overall_sum_depth_of_matched_kmers_in_input: overall_sum_depth_for_db,
+                    overall_avg_depth_of_matched_kmers_in_input: if num_overall_matched_kmers > 0 {
+                        overall_sum_depth_for_db as f64 / num_overall_matched_kmers as f64
+                    } else {
+                        0.0
+                    },
+                    proportion_input_kmers_in_db_overall: if total_unique_input_kmers_after_filter
+                        > 0
+                    {
+                        num_overall_matched_kmers as f64
+                            / total_unique_input_kmers_after_filter as f64
+                    } else {
+                        0.0
+                    },
+                    proportion_db_kmers_covered_overall: if total_kmers_in_db_union > 0 {
+                        num_overall_matched_kmers as f64 / total_kmers_in_db_union as f64
+                    } else {
+                        0.0
+                    },
+                    references: per_reference_results,
+                });
+                pb_classify.inc(1); // Increment after processing each database
             }
-
-            let num_matched_for_ref = matched_kmers_for_ref_set.len();
-            let total_kmers_in_ref = ref_kmers_set.len();
-
-            per_reference_results.push(ReferenceClassificationResult {
-                reference_name: ref_name.clone(),
-                total_kmers_in_reference: total_kmers_in_ref,
-                input_kmers_hitting_reference: num_matched_for_ref,
-                sum_depth_of_matched_kmers_in_input: sum_depth_for_ref,
-                avg_depth_of_matched_kmers_in_input: if num_matched_for_ref > 0 {
-                    sum_depth_for_ref as f64 / num_matched_for_ref as f64
-                } else { 0.0 },
-                proportion_input_kmers_hitting_reference: if total_unique_input_kmers_after_filter > 0 {
-                    num_matched_for_ref as f64 / total_unique_input_kmers_after_filter as f64
-                } else { 0.0 },
-                reference_breadth_of_coverage: if total_kmers_in_ref > 0 {
-                    num_matched_for_ref as f64 / total_kmers_in_ref as f64
-                } else { 0.0 },
-            });
-        }
-
-        // Calculate sum of depths for overall_matched_kmers_in_db_set
-        // This needs to iterate input_kmer_counts again, specifically for k-mers in overall_matched_kmers_in_db_set
-        overall_sum_depth_for_db = overall_matched_kmers_in_db_set.iter()
-            .map(|kmer| filtered_input_kmer_counts.get(kmer).copied().unwrap_or(0))
-            .sum();
-
-        let num_overall_matched_kmers = overall_matched_kmers_in_db_set.len();
-        // ---- END DEBUG PRINT ----
-        let total_kmers_in_db_union = kmer_db_v2.total_unique_kmers();
-
-        db_results.push(DatabaseClassificationResult {
-            database_path: db_path_str,
-            database_kmer_size: kmer_db_v2.k,
-            total_unique_kmers_in_db_across_references: total_kmers_in_db_union,
-            overall_input_kmers_matched_in_db: num_overall_matched_kmers,
-            overall_sum_depth_of_matched_kmers_in_input: overall_sum_depth_for_db,
-            overall_avg_depth_of_matched_kmers_in_input: if num_overall_matched_kmers > 0 {
-                overall_sum_depth_for_db as f64 / num_overall_matched_kmers as f64
-            } else { 0.0 },
-            proportion_input_kmers_in_db_overall: if total_unique_input_kmers_after_filter > 0 {
-                num_overall_matched_kmers as f64 / total_unique_input_kmers_after_filter as f64
-            } else { 0.0 },
-            proportion_db_kmers_covered_overall: if total_kmers_in_db_union > 0 {
-                num_overall_matched_kmers as f64 / total_kmers_in_db_union as f64
-            } else { 0.0 },
-            references: per_reference_results,
-        });
-        pb_classify.inc(1); // Increment after processing each database
-    }
-    Ok(()) // Return Ok from the closure
-    })?;
+            Ok(()) // Return Ok from the closure
+        },
+    )?;
 
     // --- 4. Write output ---
     let final_output = ClassificationOutput {
@@ -260,12 +310,8 @@ pub fn run_classify(args: ClassifyArgs) -> Result<()> {
     };
 
     info!("Writing classification results to: {:?}", args.output_file);
-    let output_file = File::create(&args.output_file).with_context(|| {
-        format!(
-            "Failed to create output JSON file: {:?}",
-            args.output_file
-        )
-    })?;
+    let output_file = File::create(&args.output_file)
+        .with_context(|| format!("Failed to create output JSON file: {:?}", args.output_file))?;
     let writer = BufWriter::new(output_file);
     serde_json::to_writer_pretty(writer, &final_output).with_context(|| {
         format!(
@@ -273,6 +319,49 @@ pub fn run_classify(args: ClassifyArgs) -> Result<()> {
             args.output_file
         )
     })?;
+
+    // --- 5. Optionally write TSV output ---
+    if let Some(tsv_path) = &args.output_tsv {
+        info!("Writing classification summary TSV to: {:?}", tsv_path);
+        let tsv_file = File::create(tsv_path)
+            .with_context(|| format!("Failed to create output TSV file: {:?}", tsv_path))?;
+        let mut tsv_writer = csv::WriterBuilder::new()
+            .delimiter(b'\t')
+            .from_writer(BufWriter::new(tsv_file));
+
+        // Write header
+        tsv_writer.write_record(&[
+            "InputFile",
+            "Database",
+            "Reference",
+            "TotalKmersInReference",
+            "InputKmersHittingReference",
+            "SumDepthMatchedKmers",
+            "AvgDepthMatchedKmers",
+            "ProportionInputKmersHittingReference",
+            "ReferenceBreadthOfCoverage",
+        ])?;
+
+        // Write data rows
+        for db_res in &final_output.databases_analyzed {
+            for ref_res in &db_res.references {
+                // Note: ref_res here are already filtered by min_coverage
+                tsv_writer.write_record(&[
+                    final_output.input_file_path.clone(),
+                    db_res.database_path.clone(),
+                    ref_res.reference_name.clone(),
+                    ref_res.total_kmers_in_reference.to_string(),
+                    ref_res.input_kmers_hitting_reference.to_string(),
+                    ref_res.sum_depth_of_matched_kmers_in_input.to_string(),
+                    format!("{:.4}", ref_res.avg_depth_of_matched_kmers_in_input),
+                    format!("{:.4}", ref_res.proportion_input_kmers_hitting_reference),
+                    format!("{:.4}", ref_res.reference_breadth_of_coverage),
+                ])?;
+            }
+        }
+        tsv_writer.flush()?;
+        info!("TSV summary successfully written to {:?}", tsv_path);
+    }
 
     info!("Classification successfully completed.");
     Ok(())

--- a/orion-kmer/src/commands/mod.rs
+++ b/orion-kmer/src/commands/mod.rs
@@ -16,8 +16,9 @@ pub fn dispatch_command(command: Commands, threads: usize, verbose: u8) -> Resul
         _ => log::LevelFilter::Trace,
     };
     // Allow re-init of logger for tests, handle error if already initialized
-    let _ = env_logger::Builder::new().filter_level(log_level).try_init();
-
+    let _ = env_logger::Builder::new()
+        .filter_level(log_level)
+        .try_init();
 
     // Initialize rayon thread pool
     crate::utils::initialize_rayon_pool(crate::utils::get_num_threads(threads))?;

--- a/orion-kmer/src/commands/query.rs
+++ b/orion-kmer/src/commands/query.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use log::info;
-use needletail::{parse_fastx_file, Sequence}; // Corrected import order
+use needletail::{Sequence, parse_fastx_file}; // Corrected import order
 use rayon::prelude::*;
 use std::{
     collections::HashSet, // Required for the unified k-mer set
@@ -65,10 +65,8 @@ pub fn run_query(args: QueryArgs) -> Result<()> {
     );
 
     let num_records = records.len() as u64;
-    let matching_read_ids: Vec<Vec<u8>> = track_progress_and_resources(
-        "Querying reads against database",
-        num_records,
-        |pb_query| {
+    let matching_read_ids: Vec<Vec<u8>> =
+        track_progress_and_resources("Querying reads against database", num_records, |pb_query| {
             let result: Vec<Vec<u8>> = records
                 .par_iter()
                 .filter_map(|(read_id_bytes, read_seq_vec)| {
@@ -95,7 +93,6 @@ pub fn run_query(args: QueryArgs) -> Result<()> {
                     // However, indicatif is generally efficient.
                     pb_query.inc(1);
 
-
                     if kmer_hits >= args.min_hits {
                         Some(read_id_bytes.clone())
                     } else {
@@ -104,8 +101,7 @@ pub fn run_query(args: QueryArgs) -> Result<()> {
                 })
                 .collect();
             Ok(result)
-        },
-    )?;
+        })?;
 
     info!(
         "Found {} reads matching criteria (min_hits: {}). Writing to output...",

--- a/orion-kmer/src/errors.rs
+++ b/orion-kmer/src/errors.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf; // Added for KmerSizeMismatchValidation
 use thiserror::Error;
 
-
 #[derive(Error, Debug)]
 pub enum OrionKmerError {
     #[error("Invalid K-mer size: {0}. Must be between 1 and 32.")]
@@ -28,7 +27,9 @@ pub enum OrionKmerError {
     #[error("User-provided k-mer size {0} does not match k-mer size {1} from database: {2:?}")]
     KmerSizeMismatchValidation(u8, u8, PathBuf),
 
-    #[error("Effective k-mer size {0} (from first database) does not match k-mer size {1} from database: {2:?}")]
+    #[error(
+        "Effective k-mer size {0} (from first database) does not match k-mer size {1} from database: {2:?}"
+    )]
     KmerSizeMismatchBetweenDatabases(u8, u8, PathBuf), // Specific for classify
 
     #[error("Generic error: {0}")]

--- a/orion-kmer/src/kmer.rs
+++ b/orion-kmer/src/kmer.rs
@@ -114,32 +114,46 @@ mod tests {
         let k = 4;
         // Input sequence TTTTGGGG
         let tttt_val = seq_to_u64(b"TTTT", k).unwrap(); // 255
-        let tttt_canon = canonical_u64(tttt_val, k);   // Should be AAAA (0)
-        let aaaa_val = seq_to_u64(b"AAAA", k).unwrap();   // 0
-        assert_eq!(tttt_canon, aaaa_val, "Canonical of TTTT should be AAAA value (0)");
+        let tttt_canon = canonical_u64(tttt_val, k); // Should be AAAA (0)
+        let aaaa_val = seq_to_u64(b"AAAA", k).unwrap(); // 0
+        assert_eq!(
+            tttt_canon, aaaa_val,
+            "Canonical of TTTT should be AAAA value (0)"
+        );
 
         let tggg_val = seq_to_u64(b"TGGG", k).unwrap(); // 234 (11101010)
-        let tggg_canon = canonical_u64(tggg_val, k);   // RC is CCCA (01010100 = 84). So canon is CCCA (84).
-        let ccca_val = seq_to_u64(b"CCCA", k).unwrap();   // 84
-        assert_eq!(tggg_canon, ccca_val, "Canonical of TGGG should be CCCA value (84)");
+        let tggg_canon = canonical_u64(tggg_val, k); // RC is CCCA (01010100 = 84). So canon is CCCA (84).
+        let ccca_val = seq_to_u64(b"CCCA", k).unwrap(); // 84
+        assert_eq!(
+            tggg_canon, ccca_val,
+            "Canonical of TGGG should be CCCA value (84)"
+        );
 
         // DB sequence GGGAAAAATTTT
         let ggga_val = seq_to_u64(b"GGGA", k).unwrap(); // 168 (10101000)
-        let ggga_canon = canonical_u64(ggga_val, k);   // RC is TCCC (11010101 = 213). So canon is GGGA (168).
-        assert_eq!(ggga_canon, ggga_val, "Canonical of GGGA (168) should be GGGA (168)");
+        let ggga_canon = canonical_u64(ggga_val, k); // RC is TCCC (11010101 = 213). So canon is GGGA (168).
+        assert_eq!(
+            ggga_canon, ggga_val,
+            "Canonical of GGGA (168) should be GGGA (168)"
+        );
         // This was the line that failed: assert_eq!(ggga_canon, ccca_val) which is 168 == 84 (false)
 
         // Critical checks based on correct canonicals:
         // 1. Input TTTT (canon AAAA) vs DB AAAA (canon AAAA)
         let db_aaaa_from_db_seq_val = seq_to_u64(b"AAAA", k).unwrap();
         let db_aaaa_from_db_seq_canon = canonical_u64(db_aaaa_from_db_seq_val, k);
-        assert_eq!(tttt_canon, db_aaaa_from_db_seq_canon, "Canon(TTTT) from input should match Canon(AAAA) from DB");
+        assert_eq!(
+            tttt_canon, db_aaaa_from_db_seq_canon,
+            "Canon(TTTT) from input should match Canon(AAAA) from DB"
+        );
 
         // 2. Input TGGG (canon CCCA=84) vs DB GGGA (canon GGGA=168)
         // These should NOT match.
-        assert_ne!(tggg_canon, ggga_canon, "Canon(TGGG) from input should NOT match Canon(GGGA) from DB");
+        assert_ne!(
+            tggg_canon, ggga_canon,
+            "Canon(TGGG) from input should NOT match Canon(GGGA) from DB"
+        );
     }
-
 
     #[test]
     fn test_dna_base_to_u64() {

--- a/orion-kmer/src/utils.rs
+++ b/orion-kmer/src/utils.rs
@@ -63,7 +63,9 @@ where
     let pb = ProgressBar::new(total_items);
     pb.set_style(
         ProgressStyle::default_bar()
-            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})")
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
+            )
             .unwrap_or_else(|e| {
                 debug!("Error setting progress bar style: {}", e);
                 ProgressStyle::default_bar()

--- a/orion-kmer/tests/build_tests.rs
+++ b/orion-kmer/tests/build_tests.rs
@@ -20,7 +20,6 @@ fn run_build_and_load_db_v2(
     let mut input_file_paths: Vec<PathBuf> = Vec::new();
     let mut input_filenames: Vec<String> = Vec::new();
 
-
     for (name, content) in &input_files_content {
         let file_path = temp_dir.path().join(name);
         // Ensure parent directory exists if `name` includes subdirectories.
@@ -70,15 +69,13 @@ fn kmers_from_strings(strs: &[&str], k: u8) -> HashSet<u64> {
         .collect()
 }
 
-
 const SAMPLE1_FASTA_CONTENT: &str =
     ">seq1\nACGTACGTACGT\n>seq2\nTTTTCCCCGGGGAAAA\n>seq3\nAgCtAgCtNaCcGgTt";
 const MINI_FASTA_CONTENT: &str = ">s1\nACGT\n>s2\nACGT"; // Same k-mers
 
 #[test]
 fn test_build_simple_fasta_k3() -> Result<(), Box<dyn std::error::Error>> {
-    let kmer_db_v2 =
-        run_build_and_load_db_v2(3, vec![("sample1.fasta", SAMPLE1_FASTA_CONTENT)])?;
+    let kmer_db_v2 = run_build_and_load_db_v2(3, vec![("sample1.fasta", SAMPLE1_FASTA_CONTENT)])?;
 
     assert_eq!(kmer_db_v2.k, 3);
     assert_eq!(kmer_db_v2.references.len(), 1);
@@ -122,10 +119,10 @@ fn test_build_multiple_files_k4_v2() -> Result<(), Box<dyn std::error::Error>> {
         4,
         vec![
             ("s1.fa", ">s1\nACGTACGT"), // K-mers: ACGT, CGTA, GTAC, TACG (CGTA), ACGT
-                                        // Canonical unique for s1.fa: ACGT, CGTA, GTAC
+            // Canonical unique for s1.fa: ACGT, CGTA, GTAC
             ("s2.fa", ">s2\nTACGTACG"), // K-mers: TACG (CGTA), ACGT, CGTA, GTAC, TACG (CGTA)
-                                        // Canonical unique for s2.fa: ACGT, CGTA, GTAC
-            ("s3.fa", ">s3\nGGGATCCC")  // K-mers: GGGA, GGAT, GATC, ATCC, TCCC
+            // Canonical unique for s2.fa: ACGT, CGTA, GTAC
+            ("s3.fa", ">s3\nGGGATCCC"), // K-mers: GGGA, GGAT, GATC, ATCC, TCCC
                                         // Canonical: CCC(GGGA), ATCC(GGAT), GATC, ATCC, GGG(TCCC)
                                         // Unique for s3.fa: CCC, ATCC, GATC
         ],
@@ -140,20 +137,26 @@ fn test_build_multiple_files_k4_v2() -> Result<(), Box<dyn std::error::Error>> {
     let expected_s2_kmers = kmers_from_strings(&["ACGT", "CGTA", "GTAC"], 4); // Same as s1
     let expected_s3_kmers = kmers_from_strings(&["GGGA", "GGAT", "GATC", "ATCC", "TCCC"], 4);
 
-
     assert_eq!(kmer_db_v2.references["s1.fa"], expected_s1_kmers);
     assert_eq!(kmer_db_v2.references["s2.fa"], expected_s2_kmers);
     assert_eq!(kmer_db_v2.references["s3.fa"], expected_s3_kmers);
 
     // Total unique k-mers: (ACGT, CGTA, GTAC) U (CCC, ATCC, GATC) = 6
-    let all_expected_unique_kmers = expected_s1_kmers.union(&expected_s3_kmers).cloned().collect::<HashSet<u64>>();
-    assert_eq!(kmer_db_v2.total_unique_kmers(), all_expected_unique_kmers.len());
-    assert_eq!(kmer_db_v2.get_all_kmers_unified(), all_expected_unique_kmers);
-
+    let all_expected_unique_kmers = expected_s1_kmers
+        .union(&expected_s3_kmers)
+        .cloned()
+        .collect::<HashSet<u64>>();
+    assert_eq!(
+        kmer_db_v2.total_unique_kmers(),
+        all_expected_unique_kmers.len()
+    );
+    assert_eq!(
+        kmer_db_v2.get_all_kmers_unified(),
+        all_expected_unique_kmers
+    );
 
     Ok(())
 }
-
 
 #[test]
 fn test_build_0_byte_empty_file() -> Result<(), Box<dyn std::error::Error>> {
@@ -197,7 +200,6 @@ fn test_build_fasta_with_no_sequences() -> Result<(), Box<dyn std::error::Error>
     Ok(())
 }
 
-
 #[test]
 fn test_build_malformed_fasta_file() -> Result<(), Box<dyn std::error::Error>> {
     // A file that is not valid FASTA (e.g. binary, or bad header) should cause an error during parsing.
@@ -225,7 +227,6 @@ fn test_build_malformed_fasta_file() -> Result<(), Box<dyn std::error::Error>> {
     ));
     Ok(())
 }
-
 
 #[test]
 fn test_build_invalid_k_too_large() {

--- a/orion-kmer/tests/classify_tests.rs
+++ b/orion-kmer/tests/classify_tests.rs
@@ -1,4 +1,5 @@
 use assert_cmd::prelude::*;
+use csv;
 use predicates::prelude::*;
 use serde_json::Value as JsonValue;
 use std::{
@@ -37,14 +38,17 @@ fn build_db_for_classify(
     let db_file_name = format!("{}_{}.db", db_name_prefix, uuid::Uuid::new_v4().simple());
     let output_db_path = db_output_dir.path().join(db_file_name);
 
-    cmd_build.arg("build")
+    cmd_build
+        .arg("build")
         .arg("-k")
         .arg(k.to_string())
         .arg("-o")
         .arg(&output_db_path);
 
     for input_path_str_obj in &input_file_paths_for_build {
-        cmd_build.arg("-g").arg(input_path_str_obj.to_str().unwrap());
+        cmd_build
+            .arg("-g")
+            .arg(input_path_str_obj.to_str().unwrap());
     }
 
     cmd_build.assert().success();
@@ -53,11 +57,13 @@ fn build_db_for_classify(
 
 // Helper to run the classify command and return the parsed JSON output
 fn run_classify_get_json(
-    input_content: &str,   // Content of the main input file for classification
-    input_filename: &str,  // Filename for the main input file
+    input_content: &str,  // Content of the main input file for classification
+    input_filename: &str, // Filename for the main input file
     db_paths: &[PathBuf],
     k_value_user: Option<u8>, // Optional k value provided by user
     min_kmer_freq: Option<usize>,
+    min_coverage: Option<f64>,
+    output_tsv_path_option: Option<PathBuf>,
 ) -> Result<JsonValue, Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
 
@@ -89,6 +95,12 @@ fn run_classify_get_json(
     if let Some(freq) = min_kmer_freq {
         cmd.arg("--min-kmer-frequency").arg(freq.to_string());
     }
+    if let Some(cov) = min_coverage {
+        cmd.arg("--min-coverage").arg(cov.to_string());
+    }
+    if let Some(tsv_path) = &output_tsv_path_option {
+        cmd.arg("--output-tsv").arg(tsv_path);
+    }
 
     cmd.assert().success();
 
@@ -97,10 +109,10 @@ fn run_classify_get_json(
     Ok(json_data)
 }
 
-
 // --- Test Cases ---
 
-const INPUT_FASTA_BASIC: &str = ">input_seq1\nACGTACGT\n>input_seq2\nACGTACGT\n>input_seq3\nTTTTGGGG";
+const INPUT_FASTA_BASIC: &str =
+    ">input_seq1\nACGTACGT\n>input_seq2\nACGTACGT\n>input_seq3\nTTTTGGGG";
 // For k=4:
 // input_seq1: ACGT (c), CGTA (c), GTAC (c), TACG (c->CGTA) => ACGT, CGTA, GTAC. Counts: ACGT:1, CGTA:2, GTAC:1
 // input_seq2: ACGT (c), CGTA (c), GTAC (c), TACG (c->CGTA) => ACGT, CGTA, GTAC. Counts: ACGT:1, CGTA:2, GTAC:1
@@ -114,7 +126,7 @@ const DB1_REF2_FASTA: &str = ">db1_refB\nGGGAAAAATTTT"; // k=4: GGGA(CCCA), GGAA
 
 // DB2 will contain one reference
 const DB2_REF1_FASTA: &str = ">db2_refC\nACGTTACGTT"; // k=4: ACGT, CGTT, GTTT(AAAC), TTAC(GTAA), TACG(CGTA)
-                                                   // Unique: ACGT, CGTT, AAAC, GTAA, CGTA
+// Unique: ACGT, CGTT, AAAC, GTAA, CGTA
 
 #[test]
 fn test_classify_basic_fasta_input() -> Result<(), Box<dyn std::error::Error>> {
@@ -124,7 +136,10 @@ fn test_classify_basic_fasta_input() -> Result<(), Box<dyn std::error::Error>> {
     // Build DB1
     let db1_path = build_db_for_classify(
         k,
-        vec![("db1_refA.fa", DB1_REF1_FASTA), ("db1_refB.fa", DB1_REF2_FASTA)],
+        vec![
+            ("db1_refA.fa", DB1_REF1_FASTA),
+            ("db1_refB.fa", DB1_REF2_FASTA),
+        ],
         &temp_db_storage,
         "db1",
     )?;
@@ -142,9 +157,16 @@ fn test_classify_basic_fasta_input() -> Result<(), Box<dyn std::error::Error>> {
         &[db1_path.clone(), db2_path.clone()], // Use clone if paths are needed later
         Some(k),
         None, // Default min_kmer_frequency = 1
+        None, // Default min_coverage = 0.0
+        None, // No TSV output for this test
     )?;
 
-    assert!(results["input_file_path"].as_str().unwrap().ends_with("input.fa"));
+    assert!(
+        results["input_file_path"]
+            .as_str()
+            .unwrap()
+            .ends_with("input.fa")
+    );
     assert_eq!(results["total_unique_kmers_in_input"], 8); // Corrected from 7 to 8
     assert_eq!(results["min_kmer_frequency_filter"], 1);
     assert_eq!(results["databases_analyzed"].as_array().unwrap().len(), 2);
@@ -166,35 +188,111 @@ fn test_classify_basic_fasta_input() -> Result<(), Box<dyn std::error::Error>> {
     // Input CCCA (canon CCCA) does NOT match DB GGGA (canon GGGA).
     assert_eq!(db1_results["overall_input_kmers_matched_in_db"], 4); // Corrected from 5
     // Depths from input (corrected): ACGT(4), CGTA(4), GTAC(2), AAAA(1) -> Sum = 4+4+2+1 = 11
-    assert_eq!(db1_results["overall_sum_depth_of_matched_kmers_in_input"], 11); // Corrected from 12
-    assert!((db1_results["overall_avg_depth_of_matched_kmers_in_input"].as_f64().unwrap() - (11.0/4.0)).abs() < 1e-6); // Corrected
-    assert!((db1_results["proportion_input_kmers_in_db_overall"].as_f64().unwrap() - (4.0/8.0)).abs() < 1e-6); // Corrected
-    assert!((db1_results["proportion_db_kmers_covered_overall"].as_f64().unwrap() - (4.0/9.0)).abs() < 1e-6); // Corrected
+    assert_eq!(
+        db1_results["overall_sum_depth_of_matched_kmers_in_input"],
+        11
+    ); // Corrected from 12
+    assert!(
+        (db1_results["overall_avg_depth_of_matched_kmers_in_input"]
+            .as_f64()
+            .unwrap()
+            - (11.0 / 4.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
+    assert!(
+        (db1_results["proportion_input_kmers_in_db_overall"]
+            .as_f64()
+            .unwrap()
+            - (4.0 / 8.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
+    assert!(
+        (db1_results["proportion_db_kmers_covered_overall"]
+            .as_f64()
+            .unwrap()
+            - (4.0 / 9.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
 
     assert_eq!(db1_results["references"].as_array().unwrap().len(), 2);
 
     // DB1 Ref A ("db1_refA.fa") - k-mers {ACGT, CGTA, GTAC}
     // Matches from input: {ACGT, CGTA, GTAC} (3 unique)
-    let db1_refa_res = db1_results["references"].as_array().unwrap().iter().find(|r| r["reference_name"] == "db1_refA.fa").unwrap();
+    let db1_refa_res = db1_results["references"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["reference_name"] == "db1_refA.fa")
+        .unwrap();
     assert_eq!(db1_refa_res["total_kmers_in_reference"], 3);
     assert_eq!(db1_refa_res["input_kmers_hitting_reference"], 3);
     // Depths for these from input: ACGT(4) + CGTA(4) + GTAC(2) = 10
     assert_eq!(db1_refa_res["sum_depth_of_matched_kmers_in_input"], 10);
-    assert!((db1_refa_res["avg_depth_of_matched_kmers_in_input"].as_f64().unwrap() - (10.0/3.0)).abs() < 1e-6);
-    assert!((db1_refa_res["proportion_input_kmers_hitting_reference"].as_f64().unwrap() - (3.0/8.0)).abs() < 1e-6);
-    assert!((db1_refa_res["reference_breadth_of_coverage"].as_f64().unwrap() - (3.0/3.0)).abs() < 1e-6);
+    assert!(
+        (db1_refa_res["avg_depth_of_matched_kmers_in_input"]
+            .as_f64()
+            .unwrap()
+            - (10.0 / 3.0))
+            .abs()
+            < 1e-6
+    );
+    assert!(
+        (db1_refa_res["proportion_input_kmers_hitting_reference"]
+            .as_f64()
+            .unwrap()
+            - (3.0 / 8.0))
+            .abs()
+            < 1e-6
+    );
+    assert!(
+        (db1_refa_res["reference_breadth_of_coverage"]
+            .as_f64()
+            .unwrap()
+            - (3.0 / 3.0))
+            .abs()
+            < 1e-6
+    );
 
     // DB1 Ref B ("db1_refB.fa") - k-mers {GGGA(canon GGGA), AAAA(canon AAAA), TTCC, TTTC, ATTT, AATT}
     // Matches from input: {AAAA} (1 unique)
     // Input CCCA (canon CCCA) does not match DB GGGA (canon GGGA).
-    let db1_refb_res = db1_results["references"].as_array().unwrap().iter().find(|r| r["reference_name"] == "db1_refB.fa").unwrap();
+    let db1_refb_res = db1_results["references"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["reference_name"] == "db1_refB.fa")
+        .unwrap();
     assert_eq!(db1_refb_res["total_kmers_in_reference"], 6);
     assert_eq!(db1_refb_res["input_kmers_hitting_reference"], 1); // Corrected from 2
     // Depths for these from input: AAAA(1) = 1
     assert_eq!(db1_refb_res["sum_depth_of_matched_kmers_in_input"], 1); // Corrected from 2
-    assert!((db1_refb_res["avg_depth_of_matched_kmers_in_input"].as_f64().unwrap() - (1.0/1.0)).abs() < 1e-6); // Corrected
-    assert!((db1_refb_res["proportion_input_kmers_hitting_reference"].as_f64().unwrap() - (1.0/8.0)).abs() < 1e-6); // Corrected
-    assert!((db1_refb_res["reference_breadth_of_coverage"].as_f64().unwrap() - (1.0/6.0)).abs() < 1e-6); // Corrected
+    assert!(
+        (db1_refb_res["avg_depth_of_matched_kmers_in_input"]
+            .as_f64()
+            .unwrap()
+            - (1.0 / 1.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
+    assert!(
+        (db1_refb_res["proportion_input_kmers_hitting_reference"]
+            .as_f64()
+            .unwrap()
+            - (1.0 / 8.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
+    assert!(
+        (db1_refb_res["reference_breadth_of_coverage"]
+            .as_f64()
+            .unwrap()
+            - (1.0 / 6.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
 
     // --- Assertions for DB2 ---
     // DB2_REF1_FASTA (`ACGTTACGTT` -> k=4: {ACGT, CGTT, AAAC (from GTTT), GTAA (from TTAC), CGTA (from TACG)}) = 5 unique k-mers
@@ -211,10 +309,34 @@ fn test_classify_basic_fasta_input() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(db2_results["total_unique_kmers_in_db_across_references"], 5);
     assert_eq!(db2_results["overall_input_kmers_matched_in_db"], 2); // Corrected from 3
     // Depths: ACGT(4), CGTA(4) -> Sum = 4+4 = 8
-    assert_eq!(db2_results["overall_sum_depth_of_matched_kmers_in_input"], 8); // Corrected from 7
-    assert!((db2_results["overall_avg_depth_of_matched_kmers_in_input"].as_f64().unwrap() - (8.0/2.0)).abs() < 1e-6); // Corrected
-    assert!((db2_results["proportion_input_kmers_in_db_overall"].as_f64().unwrap() - (2.0/8.0)).abs() < 1e-6); // Corrected
-    assert!((db2_results["proportion_db_kmers_covered_overall"].as_f64().unwrap() - (2.0/5.0)).abs() < 1e-6); // Corrected
+    assert_eq!(
+        db2_results["overall_sum_depth_of_matched_kmers_in_input"],
+        8
+    ); // Corrected from 7
+    assert!(
+        (db2_results["overall_avg_depth_of_matched_kmers_in_input"]
+            .as_f64()
+            .unwrap()
+            - (8.0 / 2.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
+    assert!(
+        (db2_results["proportion_input_kmers_in_db_overall"]
+            .as_f64()
+            .unwrap()
+            - (2.0 / 8.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
+    assert!(
+        (db2_results["proportion_db_kmers_covered_overall"]
+            .as_f64()
+            .unwrap()
+            - (2.0 / 5.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
 
     assert_eq!(db2_results["references"].as_array().unwrap().len(), 1);
     let db2_refc_res = &db2_results["references"][0];
@@ -222,9 +344,30 @@ fn test_classify_basic_fasta_input() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(db2_refc_res["total_kmers_in_reference"], 5);
     assert_eq!(db2_refc_res["input_kmers_hitting_reference"], 2); // Corrected from 3
     assert_eq!(db2_refc_res["sum_depth_of_matched_kmers_in_input"], 8); // Corrected from 7
-    assert!((db2_refc_res["avg_depth_of_matched_kmers_in_input"].as_f64().unwrap() - (8.0/2.0)).abs() < 1e-6); // Corrected
-    assert!((db2_refc_res["proportion_input_kmers_hitting_reference"].as_f64().unwrap() - (2.0/8.0)).abs() < 1e-6); // Corrected
-    assert!((db2_refc_res["reference_breadth_of_coverage"].as_f64().unwrap() - (2.0/5.0)).abs() < 1e-6); // Corrected
+    assert!(
+        (db2_refc_res["avg_depth_of_matched_kmers_in_input"]
+            .as_f64()
+            .unwrap()
+            - (8.0 / 2.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
+    assert!(
+        (db2_refc_res["proportion_input_kmers_hitting_reference"]
+            .as_f64()
+            .unwrap()
+            - (2.0 / 8.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
+    assert!(
+        (db2_refc_res["reference_breadth_of_coverage"]
+            .as_f64()
+            .unwrap()
+            - (2.0 / 5.0))
+            .abs()
+            < 1e-6
+    ); // Corrected
 
     Ok(())
 }
@@ -235,7 +378,12 @@ fn test_classify_min_kmer_frequency_filter() -> Result<(), Box<dyn std::error::E
     let temp_db_storage = TempDir::new()?;
 
     // DB contains: ACGT, CGTA, GTAC
-    let db_path = build_db_for_classify(k, vec![("db_ref.fa", DB1_REF1_FASTA)], &temp_db_storage, "db_minfreq")?;
+    let db_path = build_db_for_classify(
+        k,
+        vec![("db_ref.fa", DB1_REF1_FASTA)],
+        &temp_db_storage,
+        "db_minfreq",
+    )?;
 
     // New simpler input:
     // >S1\nACGTACGT -> ACGT (1), CGTA (2), GTAC (1)
@@ -254,30 +402,76 @@ fn test_classify_min_kmer_frequency_filter() -> Result<(), Box<dyn std::error::E
         &[db_path.clone()],
         Some(k),
         Some(2), // Set min_kmer_frequency to 2
+        None,    // Default min_coverage
+        None,    // No TSV output
     )?;
 
-    assert_eq!(results["total_unique_kmers_in_input"], 2, "Total unique input k-mers after filter: {{ACGT:3, CGTA:2}}");
+    assert_eq!(
+        results["total_unique_kmers_in_input"], 2,
+        "Total unique input k-mers after filter: {{ACGT:3, CGTA:2}}"
+    );
     assert_eq!(results["min_kmer_frequency_filter"], 2);
 
     let db_res = &results["databases_analyzed"][0];
-    assert_eq!(db_res["total_unique_kmers_in_db_across_references"], 3, "K-mers in DB: {{ACGT, CGTA, GTAC}}");
-    assert_eq!(db_res["overall_input_kmers_matched_in_db"], 2, "Overall matched k-mers: {{ACGT, CGTA}}");
+    assert_eq!(
+        db_res["total_unique_kmers_in_db_across_references"], 3,
+        "K-mers in DB: {{ACGT, CGTA, GTAC}}"
+    );
+    assert_eq!(
+        db_res["overall_input_kmers_matched_in_db"], 2,
+        "Overall matched k-mers: {{ACGT, CGTA}}"
+    );
 
-    let actual_sum_depth = db_res["overall_sum_depth_of_matched_kmers_in_input"].as_u64().unwrap_or(0);
+    let actual_sum_depth = db_res["overall_sum_depth_of_matched_kmers_in_input"]
+        .as_u64()
+        .unwrap_or(0);
     let expected_sum_depth = (3 + 2) as u64; // ACGT count 3, CGTA count 2
     if actual_sum_depth != expected_sum_depth {
         eprintln!("Debug info for test_classify_min_kmer_frequency_filter (simplified):");
-        eprintln!("Actual overall_sum_depth_of_matched_kmers_in_input: {}", actual_sum_depth);
-        eprintln!("Expected overall_sum_depth_of_matched_kmers_in_input: {}", expected_sum_depth);
-        eprintln!("Full results JSON: {}", serde_json::to_string_pretty(&results).unwrap_or_else(|_| "Failed to serialize results".to_string()));
+        eprintln!(
+            "Actual overall_sum_depth_of_matched_kmers_in_input: {}",
+            actual_sum_depth
+        );
+        eprintln!(
+            "Expected overall_sum_depth_of_matched_kmers_in_input: {}",
+            expected_sum_depth
+        );
+        eprintln!(
+            "Full results JSON: {}",
+            serde_json::to_string_pretty(&results)
+                .unwrap_or_else(|_| "Failed to serialize results".to_string())
+        );
     }
-    assert_eq!(actual_sum_depth, expected_sum_depth, "Mismatch in overall_sum_depth_of_matched_kmers_in_input");
+    assert_eq!(
+        actual_sum_depth, expected_sum_depth,
+        "Mismatch in overall_sum_depth_of_matched_kmers_in_input"
+    );
 
     let ref_res = &db_res["references"][0]; // Assuming "db_ref.fa" is the only one
-    assert_eq!(ref_res["input_kmers_hitting_reference"], 2, "Input k-mers hitting reference: {{ACGT, CGTA}}");
-    assert_eq!(ref_res["sum_depth_of_matched_kmers_in_input"].as_u64().unwrap(), expected_sum_depth, "Per-reference sum of depths");
-    assert!((ref_res["proportion_input_kmers_hitting_reference"].as_f64().unwrap() - (2.0/2.0)).abs() < 1e-6, "Proportion input hitting ref"); // 2 matched / 2 unique in input
-    assert!((ref_res["reference_breadth_of_coverage"].as_f64().unwrap() - (2.0/3.0)).abs() < 1e-6, "Reference breadth"); // 2 matched / 3 in ref
+    assert_eq!(
+        ref_res["input_kmers_hitting_reference"], 2,
+        "Input k-mers hitting reference: {{ACGT, CGTA}}"
+    );
+    assert_eq!(
+        ref_res["sum_depth_of_matched_kmers_in_input"]
+            .as_u64()
+            .unwrap(),
+        expected_sum_depth,
+        "Per-reference sum of depths"
+    );
+    assert!(
+        (ref_res["proportion_input_kmers_hitting_reference"]
+            .as_f64()
+            .unwrap()
+            - (2.0 / 2.0))
+            .abs()
+            < 1e-6,
+        "Proportion input hitting ref"
+    ); // 2 matched / 2 unique in input
+    assert!(
+        (ref_res["reference_breadth_of_coverage"].as_f64().unwrap() - (2.0 / 3.0)).abs() < 1e-6,
+        "Reference breadth"
+    ); // 2 matched / 3 in ref
 
     Ok(())
 }
@@ -285,10 +479,15 @@ fn test_classify_min_kmer_frequency_filter() -> Result<(), Box<dyn std::error::E
 #[test]
 fn test_classify_k_validation_error() -> Result<(), Box<dyn std::error::Error>> {
     let temp_db_storage = TempDir::new()?;
-    let db_k4_path = build_db_for_classify(4, vec![("dbk4.fa", DB1_REF1_FASTA)], &temp_db_storage, "dbk4_kvalid")?;
+    let db_k4_path = build_db_for_classify(
+        4,
+        vec![("dbk4.fa", DB1_REF1_FASTA)],
+        &temp_db_storage,
+        "dbk4_kvalid",
+    )?;
 
     let mut cmd = Command::cargo_bin("orion-kmer")?;
-     let project_root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    let project_root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
     cmd.current_dir(project_root);
     let output_json_file = NamedTempFile::new()?; // Will not be written to
 
@@ -302,17 +501,27 @@ fn test_classify_k_validation_error() -> Result<(), Box<dyn std::error::Error>> 
         .arg("-o")
         .arg(output_json_file.path());
 
-    cmd.assert()
-        .failure()
-        .stderr(predicate::str::contains("User-provided k-mer size 3 does not match k-mer size 4 from database"));
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "User-provided k-mer size 3 does not match k-mer size 4 from database",
+    ));
     Ok(())
 }
 
 #[test]
 fn test_classify_k_mismatch_between_databases() -> Result<(), Box<dyn std::error::Error>> {
     let temp_db_storage = TempDir::new()?;
-    let db_k4_path = build_db_for_classify(4, vec![("dbk4.fa", DB1_REF1_FASTA)], &temp_db_storage, "dbk4_mismatch")?;
-    let db_k3_path = build_db_for_classify(3, vec![("dbk3.fa", ">seq\nACG")], &temp_db_storage, "dbk3_mismatch")?;
+    let db_k4_path = build_db_for_classify(
+        4,
+        vec![("dbk4.fa", DB1_REF1_FASTA)],
+        &temp_db_storage,
+        "dbk4_mismatch",
+    )?;
+    let db_k3_path = build_db_for_classify(
+        3,
+        vec![("dbk3.fa", ">seq\nACG")],
+        &temp_db_storage,
+        "dbk3_mismatch",
+    )?;
 
     let mut cmd = Command::cargo_bin("orion-kmer")?;
     let project_root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
@@ -330,9 +539,9 @@ fn test_classify_k_mismatch_between_databases() -> Result<(), Box<dyn std::error
         .arg("-o")
         .arg(output_json_file.path());
 
-    cmd.assert()
-        .failure()
-        .stderr(predicate::str::contains("Effective k-mer size 4 (from first database) does not match k-mer size 3 from database"));
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "Effective k-mer size 4 (from first database) does not match k-mer size 3 from database",
+    ));
     Ok(())
 }
 
@@ -341,3 +550,190 @@ fn test_classify_k_mismatch_between_databases() -> Result<(), Box<dyn std::error
 // TODO: Add test for no matches
 // TODO: Add test for input sequences shorter than k
 // TODO: Add test for empty database or reference within a database (how build handles this - it should create an empty set)
+
+#[test]
+fn test_classify_min_coverage_filter() -> Result<(), Box<dyn std::error::Error>> {
+    let k = 4;
+    let temp_db_storage = TempDir::new()?;
+
+    // DB1_REF1_FASTA (ACGT, CGTA, GTAC) - 3 k-mers
+    // DB1_REF2_FASTA (GGGA, GGAA, GAAA, AAAA, AAAT, AATT, ATTT, TTTT) -> (CCCA, TTCC, TTTC, AAAA, ATTT, AATT) - 6 unique k-mers
+    let db_path = build_db_for_classify(
+        k,
+        vec![
+            ("db_refA.fa", DB1_REF1_FASTA),
+            ("db_refB.fa", DB1_REF2_FASTA),
+        ],
+        &temp_db_storage,
+        "db_mincov",
+    )?;
+
+    // INPUT_FASTA_BASIC:
+    // Unique k-mers: {ACGT, CGTA, GTAC, TTTT, AAAC, CCAA, CCCA, GGGG} - 8 unique
+    // Counts: ACGT:2, CGTA:4, GTAC:2, TTTT:1, AAAC:1, CCAA:1, CCCA:1, GGGG:1 (Note: Original test data was slightly off, this is based on re-eval)
+    // Corrected: Input unique k-mers (k=4, min_freq=1): {ACGT:4, CGTA:4, GTAC:2, AAAA:1, CAAA:1, CCAA:1, CCCA:1, CCCC:1} (8 unique)
+
+    // Coverage for db_refA (3 k-mers: ACGT, CGTA, GTAC):
+    // Matches: ACGT, CGTA, GTAC (3 matches)
+    // Breadth: 3/3 = 1.0
+    // Coverage for db_refB (6 k-mers: GGGA, AAAA, TTCC, TTTC, ATTT, AATT):
+    // Matches: AAAA (1 match)
+    // Breadth: 1/6 = 0.1666...
+
+    // Test with min_coverage = 0.5. Expect db_refA to be present, db_refB to be filtered out.
+    let results = run_classify_get_json(
+        INPUT_FASTA_BASIC,
+        "input_mincov.fa",
+        &[db_path.clone()],
+        Some(k),
+        None,      // Default min_kmer_frequency
+        Some(0.5), // min_coverage = 0.5
+        None,      // No TSV output
+    )?;
+
+    assert_eq!(results["databases_analyzed"].as_array().unwrap().len(), 1);
+    let db_results = &results["databases_analyzed"][0];
+    assert_eq!(
+        db_results["references"].as_array().unwrap().len(),
+        1,
+        "Only one reference should pass min_coverage 0.5"
+    );
+
+    let ref_res = &db_results["references"][0];
+    assert_eq!(ref_res["reference_name"], "db_refA.fa");
+    assert!((ref_res["reference_breadth_of_coverage"].as_f64().unwrap() - 1.0).abs() < 1e-6);
+
+    // Test with min_coverage = 0.1. Expect both references.
+    let results_low_cov = run_classify_get_json(
+        INPUT_FASTA_BASIC,
+        "input_mincov_low.fa",
+        &[db_path.clone()],
+        Some(k),
+        None,
+        Some(0.1), // min_coverage = 0.1
+        None,
+    )?;
+    assert_eq!(
+        results_low_cov["databases_analyzed"][0]["references"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2,
+        "Both references should pass min_coverage 0.1"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_classify_output_tsv() -> Result<(), Box<dyn std::error::Error>> {
+    let k = 4;
+    let temp_db_storage = TempDir::new()?;
+    let db_path = build_db_for_classify(
+        k,
+        vec![
+            ("db_refA.fa", DB1_REF1_FASTA),
+            ("db_refB.fa", DB1_REF2_FASTA),
+        ],
+        &temp_db_storage,
+        "db_tsv",
+    )?;
+
+    let temp_output_dir = TempDir::new()?;
+    let tsv_output_path = temp_output_dir.path().join("output.tsv");
+
+    let _json_results = run_classify_get_json(
+        INPUT_FASTA_BASIC,
+        "input_tsv.fa",
+        &[db_path.clone()],
+        Some(k),
+        None,      // Default min_kmer_frequency
+        Some(0.5), // min_coverage = 0.5 (so only db_refA appears)
+        Some(tsv_output_path.clone()),
+    )?;
+
+    assert!(tsv_output_path.exists(), "TSV file was not created");
+
+    let tsv_content = fs::read_to_string(&tsv_output_path)?;
+    let mut reader = csv::ReaderBuilder::new()
+        .delimiter(b'\t')
+        .from_reader(tsv_content.as_bytes());
+
+    let headers = reader.headers()?.clone();
+    assert_eq!(
+        headers,
+        vec![
+            "InputFile",
+            "Database",
+            "Reference",
+            "TotalKmersInReference",
+            "InputKmersHittingReference",
+            "SumDepthMatchedKmers",
+            "AvgDepthMatchedKmers",
+            "ProportionInputKmersHittingReference",
+            "ReferenceBreadthOfCoverage"
+        ]
+    );
+
+    let records: Vec<csv::StringRecord> = reader.records().collect::<Result<_, _>>()?;
+    assert_eq!(
+        records.len(),
+        1,
+        "TSV should contain one data record due to min_coverage filter"
+    );
+
+    let record = &records[0];
+    assert!(record[0].ends_with("input_tsv.fa"));
+    assert!(record[1].contains("db_tsv")); // Check if db_path substring is present
+    assert_eq!(&record[2], "db_refA.fa");
+    assert_eq!(&record[3], "3"); // TotalKmersInReference for db_refA
+    assert_eq!(&record[4], "3"); // InputKmersHittingReference for db_refA
+    // SumDepth: ACGT(4) + CGTA(4) + GTAC(2) = 10
+    assert_eq!(&record[5], "10"); // SumDepthMatchedKmers for db_refA
+    // AvgDepth: 10/3 = 3.3333
+    assert_eq!(&record[6], "3.3333");
+    // ProportionInputKmersHittingReference: 3 / 8 unique input kmers = 0.375
+    assert_eq!(&record[7], "0.3750");
+    // ReferenceBreadthOfCoverage: 3 / 3 = 1.0
+    assert_eq!(&record[8], "1.0000");
+
+    // Test with no min_coverage (default 0.0), so both references should appear
+    let tsv_output_path_all_refs = temp_output_dir.path().join("output_all_refs.tsv");
+    let _json_results_all_refs = run_classify_get_json(
+        INPUT_FASTA_BASIC,
+        "input_tsv_all.fa",
+        &[db_path.clone()],
+        Some(k),
+        None,
+        None, // Default min_coverage (0.0)
+        Some(tsv_output_path_all_refs.clone()),
+    )?;
+
+    let tsv_content_all_refs = fs::read_to_string(&tsv_output_path_all_refs)?;
+    let mut reader_all_refs = csv::ReaderBuilder::new()
+        .delimiter(b'\t')
+        .from_reader(tsv_content_all_refs.as_bytes());
+    let records_all_refs: Vec<csv::StringRecord> =
+        reader_all_refs.records().collect::<Result<_, _>>()?;
+    assert_eq!(
+        records_all_refs.len(),
+        2,
+        "TSV should contain two data records when min_coverage is default"
+    );
+
+    // Check second record (db_refB.fa)
+    // It matches 1 kmer (AAAA) out of 6 in reference. Depth for AAAA is 1.
+    // Total unique input is 8.
+    let record_b = records_all_refs
+        .iter()
+        .find(|r| r[2] == "db_refB.fa")
+        .expect("db_refB.fa not found in TSV");
+    assert_eq!(&record_b[3], "6"); // TotalKmersInReference for db_refB
+    assert_eq!(&record_b[4], "1"); // InputKmersHittingReference for db_refB
+    assert_eq!(&record_b[5], "1"); // SumDepthMatchedKmers for db_refB (AAAA depth 1)
+    assert_eq!(&record_b[6], "1.0000"); // AvgDepth
+    assert_eq!(&record_b[7], format!("{:.4}", 1.0 / 8.0)); // ProportionInputKmersHittingReference
+    assert_eq!(&record_b[8], format!("{:.4}", 1.0 / 6.0)); // ReferenceBreadthOfCoverage
+
+    Ok(())
+}


### PR DESCRIPTION
This commit introduces two new options to the `orion-kmer classify` command:

- `--min_coverage`: Filters the output to include only reference genomes where the breadth of coverage is above the specified threshold.
- `--output_tsv`: Generates a TSV file summarizing the classification results for references that meet the minimum coverage criteria.

These features provide users with more control over the output and offer an alternative, more parseable format for the classification summary.