### PR TITLE
Refactor reader logic to fix Send bound and address test regressions

### DIFF
--- a/orion-kmer/Cargo.lock
+++ b/orion-kmer/Cargo.lock
@@ -174,6 +174,8 @@ version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -275,6 +277,27 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "darwin-libproc"
@@ -471,6 +494,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +646,7 @@ dependencies = [
  "assert_cmd",
  "bincode",
  "clap",
+ "csv",
  "dashmap",
  "env_logger",
  "flate2",
@@ -628,6 +662,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "uuid",
+ "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -1301,4 +1337,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/orion-kmer/src/commands/build.rs
+++ b/orion-kmer/src/commands/build.rs
@@ -14,7 +14,7 @@ use crate::{
     db_types::KmerDbV2, // Import the new database structure
     errors::OrionKmerError,
     kmer::{canonical_u64, seq_to_u64},
-    utils::{get_input_reader, get_output_writer, track_progress_and_resources}, // Import the wrapper function and I/O helpers
+    utils::{get_buffered_file_reader, get_output_writer, track_progress_and_resources}, // Import the wrapper function and I/O helpers
 };
 // use indicatif::ProgressBar; // Required for the closure signature - actually not needed
 
@@ -34,9 +34,9 @@ fn process_sequences_for_file(
     // let total_records = ...;
     // pb.set_length(total_records); // If using a per-file progress bar
 
-    // Use get_input_reader to handle potential compression
-    let input_buf_reader = get_input_reader(file_path)
-        .with_context(|| format!("Failed to get input reader for file: {}", path_str))?;
+    // Use get_buffered_file_reader, needletail will handle decompression
+    let input_buf_reader = get_buffered_file_reader(file_path)
+        .with_context(|| format!("Failed to get buffered file reader for file: {}", path_str))?;
 
     // Pass the BufRead to parse_fastx_reader instead of a path to parse_fastx_file
     let mut reader = parse_fastx_reader(input_buf_reader)

--- a/orion-kmer/src/commands/classify.rs
+++ b/orion-kmer/src/commands/classify.rs
@@ -3,8 +3,6 @@ use log::{debug, info}; // Removed warn
 use serde::Serialize;
 use std::{
     collections::{HashMap, HashSet},
-    fs::File,
-    io::BufWriter,
     // path::PathBuf, // Removed PathBuf, as it's not directly used as a type here
 };
 
@@ -13,7 +11,7 @@ use crate::{
     db_types::KmerDbV2,
     errors::OrionKmerError,
     kmer::{canonical_u64, seq_to_u64},
-    utils::{get_input_reader, get_output_writer, load_kmer_db_v2, track_progress_and_resources}, // Import the wrapper & I/O helpers
+    utils::{get_buffered_file_reader, get_output_writer, load_kmer_db_v2, track_progress_and_resources}, // Import the wrapper & I/O helpers
 };
 use csv;
 use needletail::{parse_fastx_reader, Sequence}; // Changed to parse_fastx_reader
@@ -141,10 +139,10 @@ pub fn run_classify(args: ClassifyArgs) -> Result<()> {
         &format!("Processing input file: {}", input_file_path_str),
         0, // 0 for indeterminate progress bar (spinner style) as we don't know total records easily
         |pb_input| {
-            // Use get_input_reader to handle potential compression
-            let input_buf_reader = get_input_reader(&args.input_file).with_context(|| {
+            // Use get_buffered_file_reader, needletail will handle decompression
+            let input_buf_reader = get_buffered_file_reader(&args.input_file).with_context(|| {
                 format!(
-                    "Failed to get input reader for file: {:?}",
+                    "Failed to get buffered file reader for file: {:?}",
                     args.input_file
                 )
             })?;

--- a/orion-kmer/tests/classify_tests.rs
+++ b/orion-kmer/tests/classify_tests.rs
@@ -726,7 +726,7 @@ fn test_classify_output_tsv() -> Result<(), Box<dyn std::error::Error>> {
     // Total unique input is 8.
     let record_b = records_all_refs
         .iter()
-        .find(|r| r[2] == "db_refB.fa")
+        .find(|r| r[2] == *"db_refB.fa")
         .expect("db_refB.fa not found in TSV");
     assert_eq!(&record_b[3], "6"); // TotalKmersInReference for db_refB
     assert_eq!(&record_b[4], "1"); // InputKmersHittingReference for db_refB

--- a/orion-kmer/tests/count_tests.rs
+++ b/orion-kmer/tests/count_tests.rs
@@ -1,5 +1,6 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
+use std::io::Read;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::PathBuf;


### PR DESCRIPTION
Initial problem: `dyn BufRead` not `Send`, required by `needletail`.

Steps taken:
1. Modified `get_input_reader` to return `Box<dyn BufRead + Send>`. This fixed the compile error but caused 9 test failures in `build_tests.rs` (k-mer content mismatches, error message changes, one panic, one `File::open` failure).

2. Investigated test failures. Hypothesized that k-mer differences were due to allowing `get_input_reader` to decompress, then passing the already-decompressed stream to `needletail` (which also can decompress), potentially using different decompression library versions or logic.

3. Revised strategy:
   - Renamed `get_input_reader` to `get_decompressed_input_reader` in `utils.rs`. It still returns `Box<dyn BufRead + Send>` and handles decompression. Used by `load_kmer_db_v2`.
   - Created `get_buffered_file_reader` in `utils.rs` returning `BufReader<File>`. This provides a raw (but buffered and `Send`-able) file stream.
   - Updated `commands/build.rs` and `commands/classify.rs` to use `get_buffered_file_reader` when calling `needletail::parse_fastx_reader`, allowing `needletail` to perform its own decompression.

This commit includes the refactored reader logic in `utils.rs` and updates to `build.rs` and `classify.rs`. Updates to `count.rs` and `query.rs` were pending. Further testing is needed to confirm all test regressions are resolved.