### PR TITLE
Fix: Resolve unresolved import error and remove unused import

### DIFF
--- a/orion-kmer/src/commands/count.rs
+++ b/orion-kmer/src/commands/count.rs
@@ -16,7 +16,7 @@ use crate::{
     cli::CountArgs,
     errors::OrionKmerError,
     kmer::{canonical_u64, seq_to_u64, u64_to_seq},
-    utils::{get_input_reader, get_output_writer, track_progress_and_resources}, // Import I/O helpers
+    utils::{get_decompressed_input_reader, get_output_writer, track_progress_and_resources}, // Import I/O helpers
 };
 // use indicatif::ProgressBar; // Not needed if progress is per file
 
@@ -55,8 +55,8 @@ pub fn run_count(args: CountArgs) -> Result<()> {
             // Update progress bar message for the current file
             pb_files.set_message(format!("Processing: {}", path_str));
 
-            // Use get_input_reader to handle potential compression
-            let input_buf_reader = get_input_reader(input_path)
+            // Use get_decompressed_input_reader to handle potential compression
+            let input_buf_reader = get_decompressed_input_reader(input_path)
                 .with_context(|| format!("Failed to get input reader for file: {}", path_str))?;
 
             // Pass the BufRead to parse_fastx_reader

--- a/orion-kmer/src/commands/query.rs
+++ b/orion-kmer/src/commands/query.rs
@@ -15,7 +15,7 @@ use crate::{
     // db_types::KmerDbV2,
     errors::OrionKmerError,
     kmer::{canonical_u64, seq_to_u64},
-    utils::{get_input_reader, get_output_writer, load_kmer_db_v2, track_progress_and_resources}, // Import the wrapper & I/O helpers
+    utils::{get_decompressed_input_reader, get_output_writer, load_kmer_db_v2, track_progress_and_resources}, // Import the wrapper & I/O helpers
 };
 // use indicatif::ProgressBar; // For passing to the closure - actually not needed
 
@@ -41,8 +41,8 @@ pub fn run_query(args: QueryArgs) -> Result<()> {
         db_all_kmers.len()
     );
 
-    // Use get_input_reader for the reads file
-    let input_buf_reader = get_input_reader(&args.reads_file).with_context(|| {
+    // Use get_decompressed_input_reader for the reads file
+    let input_buf_reader = get_decompressed_input_reader(&args.reads_file).with_context(|| {
         format!(
             "Failed to get input reader for reads file: {:?}",
             args.reads_file

--- a/orion-kmer/src/utils.rs
+++ b/orion-kmer/src/utils.rs
@@ -3,7 +3,7 @@ use flate2::{read::MultiGzDecoder, write::GzEncoder, Compression as GzCompressio
 use log::{debug, info}; // Added info
 use std::{
     fs::File,
-    io::{BufRead, BufReader, BufWriter, Read, Write}, // Added BufRead, Write, BufWriter, Read
+    io::{BufRead, BufReader, BufWriter, Write}, // Added BufRead, Write, BufWriter
     path::Path,
 };
 use xz2::{read::XzDecoder, write::XzEncoder};


### PR DESCRIPTION
- Replaced `get_input_reader` with `get_decompressed_input_reader` in `commands/count.rs` and `commands/query.rs` to resolve compilation errors.
- Removed unused `Read` import from `utils.rs`.